### PR TITLE
Changing `getNumberOfProblems` usecase to return at least 1 if the substring "Has Problems" is detected

### DIFF
--- a/server/usecases/get-lsc-status.lua
+++ b/server/usecases/get-lsc-status.lua
@@ -14,8 +14,7 @@ local function exec(address, name)
 
     local sensorInformation = lsc:getSensorInformation()
 
-    --local problems = getNumberOfProblems(sensorInformation[9])
-    local problems = sensorInformation[9]
+    local problems = getNumberOfProblems(sensorInformation[9])
     
     local state = {}
     if lsc:isWorkAllowed() then
@@ -28,10 +27,7 @@ local function exec(address, name)
         state = states.OFF
     end
 
-    --if (problems or 0) > 0 then state = states.BROKEN end
-    if string.match(problems, "Problems") ~= nil then
-        state = states.BROKEN
-    end
+    if problems > 0 then state = states.BROKEN end
     
     local status = {
         storedEU = lsc:getStoredEU(),

--- a/server/usecases/get-multiblock-status.lua
+++ b/server/usecases/get-multiblock-status.lua
@@ -28,7 +28,7 @@ local function exec(address, name)
         state = states.OFF
     end
 
-    if (problems or 0) > 0 then state = states.BROKEN end
+    if problems > 0 then state = states.BROKEN end
 
     local status = {
         progress = multiblock:getWorkProgress(),

--- a/server/usecases/get-number-of-problems.lua
+++ b/server/usecases/get-number-of-problems.lua
@@ -1,10 +1,9 @@
 local function exec(problemsString)
-    local problems = "0"
-    pcall(
-        function()
-            problems = string.sub(problemsString, string.find(problemsString, "c%d"))
-        end
-    )
+    local problems = string.match(problemsString, "Has Problems") and "1" or "0"
+    pcall(function()
+        problems =
+            string.sub(problemsString, string.find(problemsString, "c%d"))
+    end)
     return tonumber((string.gsub(problems, "c", "")))
 end
 


### PR DESCRIPTION
Moving specific LSC code to the more general purpose usecase