### PR TITLE
Add YOTT compatibility beyond integer limit

### DIFF
--- a/hud/init.lua
+++ b/hud/init.lua
@@ -9,6 +9,7 @@ local fluidDisplay = require("hud.fluiddisplay")
 local component = require("component")
 local serialization = require("serialization")
 local colors = require("lib.graphics.colors")
+parser = require("lib.utils.parser")
 --
 
 local glassData = {}
@@ -204,6 +205,34 @@ local function updateFluidData()
         end
         if doSave then
             saveFluidData()
+        end
+    end
+
+    -- YOTT tanks
+    for address, _ in pairs(component.list("gt_machine")) do
+        local info = component.proxy(address).getSensorInformation()
+        if (info[1] == "Fluid Name:") then
+            local name = parser.stripColors(info[2])
+            local id = string.lower(string.gsub(name, " ", ""))
+            local amount = parser.getInteger(info[6]) / 10
+            local capacity = parser.getInteger(info[4])
+            local data = fluidMaximums[id]
+            local maximum = 0
+            
+            if not data then
+                maxium = getMax(capacity)
+                fluidMaximums[id] = {max=maxium, name=name}
+                doSave = true
+            else
+                maximum = data.max
+                if data.max ~= amount then
+                    maxium = getMax(capacity)
+                    fluidMaximums[id] = {max=maxium, name=name}
+                    doSave = true
+                end
+            end
+
+            fluidData[id] = {amount=amount, name=name, max=maximum, id=id}
         end
     end
 end

--- a/hud/init.lua
+++ b/hud/init.lua
@@ -9,7 +9,7 @@ local fluidDisplay = require("hud.fluiddisplay")
 local component = require("component")
 local serialization = require("serialization")
 local colors = require("lib.graphics.colors")
-parser = require("lib.utils.parser")
+local parser = require("lib.utils.parser")
 --
 
 local glassData = {}
@@ -185,14 +185,14 @@ local function updateFluidData()
                 local data = fluidMaximums[id]
                 local maximum = 0
                 if not data then
-                    maxium = getMax(amount)
-                    fluidMaximums[id] = {max=maxium, name=name}
+                    maximum = getMax(amount)
+                    fluidMaximums[id] = {max=maximum, name=name}
                     doSave = true
                 else
                     maximum = data.max
                     if data.max < amount then
                         maxium = getMax(amount)
-                        fluidMaximums[id] = {max=maxium, name=name}
+                        fluidMaximums[id] = {max=maximum, name=name}
                         doSave = true
                     end
                 end
@@ -220,14 +220,14 @@ local function updateFluidData()
             local maximum = 0
             
             if not data then
-                maxium = getMax(capacity)
-                fluidMaximums[id] = {max=maxium, name=name}
+                maximum = getMax(capacity)
+                fluidMaximums[id] = {max=maximum, name=name}
                 doSave = true
             else
                 maximum = data.max
                 if data.max ~= amount then
-                    maxium = getMax(capacity)
-                    fluidMaximums[id] = {max=maxium, name=name}
+                    maximum = getMax(capacity)
+                    fluidMaximums[id] = {max=maximum, name=name}
                     doSave = true
                 end
             end

--- a/lib/utils/parser.lua
+++ b/lib/utils/parser.lua
@@ -51,4 +51,8 @@ end
 function parser.percentage(number) return
     (math.floor(number * 1000) / 10) .. "%" end
 
+function parser.stripColors(string)
+    return string.gsub(string, "§.", "")
+end
+
 return parser


### PR DESCRIPTION
AE2 limits fluids by the integer limit, so this parses the sensor information instead.

Requires an adapter facing the YOTT controller, haven't tested if this breaks with other fluid storage e.g. super tank, TFFT.