### PR TITLE
Fix YOTT readout

### DIFF
--- a/hud/init.lua
+++ b/hud/init.lua
@@ -214,7 +214,7 @@ local function updateFluidData()
         if (info[1] == "Fluid Name:") then
             local name = parser.stripColors(info[2])
             local id = string.lower(string.gsub(name, " ", ""))
-            local amount = parser.getInteger(info[6]) / 10
+            local amount = parser.getInteger(string.gsub(info[6], "%(.*%)", ""))
             local capacity = parser.getInteger(info[4])
             local data = fluidMaximums[id]
             local maximum = 0


### PR DESCRIPTION
Info Line 6 for YOTTs also contained a percentage readout.

The magic `/10` only worked for <10% full tanks, this change strips the percentage readout before parsing.